### PR TITLE
Significant change & addition

### DIFF
--- a/src/main/java/zemiA/AttributeInfo.java
+++ b/src/main/java/zemiA/AttributeInfo.java
@@ -1,0 +1,121 @@
+package zemiA;
+
+import java.util.HashSet;
+
+
+
+
+/**
+ * @author gruidae
+ */
+public class AttributeInfo implements ElementInfo {
+
+	/* ----- Attribute: 属性 ----- */
+	private String definedClass;  // 定義されているクラス
+	private AccessModifier accessModifier;  // アクセス修飾子
+	private boolean isStatic;  // 静的メソッドか否か
+	private String type;  // 型
+	private String name;  // 名前
+
+	private HashSet<Disharmony> disharmnonySet;  // Disharmonyの集合
+
+
+	/* ----- Constructor: コンストラクタ ----- */
+	AttributeInfo(String name) {
+		this.setName(name);  return;
+	}
+
+	AttributeInfo(String definedClass, String accessModifier, boolean isStatic, String type, String name) {
+		this.setDefinedClass(definedClass);
+		this.setAccessModifier(accessModifier);
+		this.setIsStatic(isStatic);
+		this.setType(type);
+		this.setName(name);
+
+		return;
+	}
+
+
+	/* ----- setter メソッド ----- */
+	public void setDefinedClass(String definedClass)
+	{
+		this.definedClass = new String(definedClass);  return;
+	}
+
+	public void setIsStatic(boolean isStatic)
+	{
+		this.isStatic = isStatic;  return;
+	}
+
+	@Override
+	public void setAccessModifier(String accessModifier)
+	{
+		switch(accessModifier) {
+		case "private":
+			this.accessModifier = AccessModifier.PRIVATE;  break;
+		case "protected":
+			this.accessModifier = AccessModifier.PROTECTED;  break;
+		case "public":
+			this.accessModifier = AccessModifier.PUBLIC;  break;
+		default:
+			this.accessModifier = AccessModifier.PACKAGE_PRIVATE;
+		}
+
+		return;
+	}
+
+	public void setType(String type)
+	{
+		this.type = new String(type);  return;
+	}
+
+	@Override
+	public void setName(String name)
+	{
+		this.name = new String(name);  return;
+	}
+
+
+	/* ----- Method: メソッド ----- */
+	@Override
+	public String toString() {
+		// TODO 自動生成されたメソッド・スタブ
+		String accessModifier = HelperToString.toString(this.accessModifier);
+		String staticStr = HelperToString.toString(this.isStatic, "static");
+		String disharmonies = HelperToString.toString(this.disharmnonySet);
+		String str
+		= String.format("%s.%s (%s, %s, %s) : %s",
+				this.definedClass, this.name, this.type, accessModifier, staticStr, disharmonies);
+		return str;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		// TODO 自動生成されたメソッド・スタブ
+		if (this == obj)  return true;
+		if (obj == null)  return false;
+		if ( !(obj instanceof ClassInfo) )  return false;
+		AttributeInfo attributeInfo = (AttributeInfo) obj;
+
+		if ( !(attributeInfo.definedClass).equals(this.definedClass) )  return false;
+		if ( !(attributeInfo.name).equals(this.name) )  return false;
+		if ( !(attributeInfo.type).equals(this.type) )  return false;
+		if ( !(attributeInfo.accessModifier).equals(this.accessModifier) )  return false;
+		if ( attributeInfo.isStatic != this.isStatic )  return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		// TODO 自動生成されたメソッド・スタブ
+		final int HASH_START = 100, HASH_CONSTANT = 10;
+		int hash = HASH_START;
+		hash = ( hash << 5 ) + this.definedClass.hashCode();
+		hash = ( hash << 5 ) + this.name.hashCode();
+		hash = ( hash << 5 ) + this.type.hashCode();
+		hash = ( hash << 5 ) + this.accessModifier.hashCode();
+		hash = this.isStatic?( (hash << 5) + HASH_CONSTANT):(hash << 5);
+		return hash;
+	}
+
+}

--- a/src/main/java/zemiA/ClassInfo.java
+++ b/src/main/java/zemiA/ClassInfo.java
@@ -1,0 +1,127 @@
+package zemiA;
+
+import java.util.HashSet;
+
+
+
+
+/**
+ * @author gruidae
+ */
+public class ClassInfo implements ElementInfo {
+
+	/* ----- Attribute: 属性 ----- */
+	enum ClassAbstraction {
+		NORMAL_CLASS, ABSTRACT_CLASS, INTERFACE_CLASS
+	}
+
+	private AccessModifier accessModifier;  // アクセス修飾子
+	private ClassAbstraction classAbstraction;  // クラスの抽象度
+	private String name;  // クラスの名前
+	private String superClassName = "java.lang.Object";  // 親クラス名
+
+	private HashSet<AttributeInfo> attributeList = new HashSet<AttributeInfo>();  // 属性の集合
+	private HashSet<MethodInfo> methodList = new HashSet<MethodInfo>();  // メソッドの集合
+
+	// private int numInherited;  // 継承された回数
+
+	private HashSet<Disharmony> disharmnonySet;  // Disharmonyの集合
+
+
+	/* ----- コンストラクタ ----- */
+	ClassInfo(String name) {
+		this.setName(name);  return;
+	}
+
+	ClassInfo(String accessModifier, boolean isAbstract, boolean isInterface, String name,
+			String superClassName)
+	{
+		this.setAccessModifier(accessModifier);
+		this.setClassAbstraction(isAbstract, isInterface);
+		this.setName(name);
+		this.setSuperClassName(superClassName);
+
+		return;
+	}
+
+
+	/* ----- setter メソッド ----- */
+	@Override
+	public void setAccessModifier(String accessModifier)
+	{
+		switch(accessModifier) {
+		case "private":
+			this.accessModifier = AccessModifier.PRIVATE;  break;
+		case "protected":
+			this.accessModifier = AccessModifier.PROTECTED;  break;
+		case "public":
+			this.accessModifier = AccessModifier.PUBLIC;  break;
+		default:
+			this.accessModifier = AccessModifier.PACKAGE_PRIVATE;
+		}
+
+		return;
+	}
+
+	public void setClassAbstraction(boolean isAbstract, boolean isInterface)
+	{
+		if ( isAbstract )  this.classAbstraction = ClassAbstraction.ABSTRACT_CLASS;
+		else if ( isInterface )  this.classAbstraction = ClassAbstraction.INTERFACE_CLASS;
+		else  this.classAbstraction = ClassAbstraction.NORMAL_CLASS;
+		return;
+	}
+
+	@Override
+	public void setName(String name)
+	{
+		this.name = new String(name);  return;
+	}
+
+	public void setSuperClassName(String superClassName)
+	{
+		this.superClassName = new String(superClassName);  return;
+	}
+
+
+	/* ----- Method: メソッド ----- */
+	@Override
+	public String toString() {
+		// TODO 自動生成されたメソッド・スタブ
+		String accessModifier = HelperToString.toString(this.accessModifier);
+		String classAbstraction = HelperToString.toString(this.classAbstraction);
+		String disharmonies = HelperToString.toString(this.disharmnonySet);
+		String str
+		= String.format("%s (%s, %s) extends %s: %s",
+				this.name, accessModifier, classAbstraction, this.superClassName, disharmonies);
+		return str;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		// TODO 自動生成されたメソッド・スタブ
+		if (this == obj)  return true;
+		if (obj == null)  return false;
+		if ( !(obj instanceof ClassInfo) )  return false;
+		ClassInfo classInfo = (ClassInfo) obj;
+
+		if ( !(classInfo.name).equals(this.name) )  return false;
+		if ( !(classInfo.accessModifier).equals(this.accessModifier) )  return false;
+		if ( !(classInfo.classAbstraction).equals(this.classAbstraction) )  return false;
+		if ( !(classInfo.superClassName).equals(this.superClassName) )  return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		// TODO 自動生成されたメソッド・スタブ
+		final int HASH_START = 100;
+		int hash = HASH_START;
+
+		hash = ( hash << 5 ) + this.name.hashCode();
+		hash = ( hash << 5 ) + this.accessModifier.hashCode();
+		hash = ( hash << 5 ) + this.classAbstraction.hashCode();
+		hash = ( hash << 5 ) + this.superClassName.hashCode();
+		return hash;
+	}
+
+}

--- a/src/main/java/zemiA/ElementInfo.java
+++ b/src/main/java/zemiA/ElementInfo.java
@@ -1,0 +1,35 @@
+package zemiA;
+
+
+
+
+/**
+ * @author gruidae
+ */
+public interface ElementInfo {
+
+	/* ----- Attribute: 属性 ----- */
+	public enum AccessModifier {  // アクセス修飾子
+		PRIVATE, PACKAGE_PRIVATE, PROTECTED, PUBLIC
+	}
+
+	public enum Disharmony {  // Disharomy の種類
+		GOD_CLASS, FEATURE_ENVY, DATA_CLASS, BRAIN_METHOD, BRAIN_CLASS, SIGNIFICANT_DUPLICATION,
+		INTENSIVE_COUPLING, DISPERSED_COUPLING, SHOTGUN_SURGERY,
+		REFUSED_PARENT_BEQUEST, TRADITION_BREAKER
+	}
+
+	/* ----- setter メソッド ----- */
+	public void setAccessModifier(String accessModifier);
+	public void setName(String name);
+
+
+	/* ----- Method: メソッド ----- */
+	@Override
+	public String toString();
+	@Override
+	public boolean equals(Object obj);
+	@Override
+	int hashCode();
+
+}

--- a/src/main/java/zemiA/HelperToString.java
+++ b/src/main/java/zemiA/HelperToString.java
@@ -1,0 +1,112 @@
+package zemiA;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import zemiA.ClassInfo.ClassAbstraction;
+import zemiA.ElementInfo.AccessModifier;
+import zemiA.ElementInfo.Disharmony;
+
+/**
+ * @author gruidae
+ *
+ * toString メソッド用のヘルパークラス.
+ */
+public class HelperToString {
+
+	/** AccessModifier -> String */
+	public static String toString(AccessModifier accessModifier)
+	{
+		String str = null;
+		switch(accessModifier) {
+		case PRIVATE:    str = "private";  break;
+		case PROTECTED:  str = "protected"; break;
+		case PUBLIC:     str = "public"; break;
+		default:          str = "package protected";
+		}
+
+		return str;
+	}
+
+
+	/** ClassAbstraction -> String */
+	public static String toString(ClassAbstraction classAbstraction)
+	{
+		String str = null;
+		switch(classAbstraction) {
+		case ABSTRACT_CLASS:   str = "abstract";  break;
+		case INTERFACE_CLASS:  str = "interface"; break;
+		default:               str = "instance";
+		}
+
+		return str;
+	}
+
+
+	/** boolean -> String */
+	public static String toString(boolean isSomething, String argumentString)
+	{
+		String str = null;
+		switch(argumentString) {
+		case "static":    str = isSomething?"static":"dynamic";  break;
+		case "abstract":  str = isSomething?", abstruct":"";  break;
+		default:          str = "";
+		}
+		return str;
+	}
+
+
+	/** ArrayList<String> -> String */
+	public static String toString(ArrayList<String> argumentsList)
+	{
+		String str = null;
+		boolean isFirst = true;
+		for (String argument: argumentsList) {
+			if (!isFirst)  str = str + ", ";
+			str = str + argument;
+			isFirst = false;
+		}
+
+		return str;
+	}
+
+
+	/** Disharmony -> String */
+	public static String toString(HashSet<Disharmony> disharmnonySet)
+	{
+		String str = null;
+		boolean isFirst = true;
+		for (Disharmony disharmony: disharmnonySet) {
+			if (!isFirst)  str = str + "  ";
+			switch(disharmony) {
+			case GOD_CLASS:
+				str = str + "\"God Class\"";  break;
+			case FEATURE_ENVY:
+				str = str + "\"Feature Envy\"";  break;
+			case DATA_CLASS:
+				str = str + "\"Data Class\"";  break;
+			case BRAIN_METHOD:
+				str = str + "\"Brain Method\"";  break;
+			case BRAIN_CLASS:
+				str = str + "\"Brain Class\"";  break;
+			case SIGNIFICANT_DUPLICATION:
+				str = str + "\"Significant_Duplication\"";  break;
+			case INTENSIVE_COUPLING:
+				str = str + "\"Intensive Coupling\"";  break;
+			case DISPERSED_COUPLING:
+				str = str + "\"Dispersed Coupling\"";  break;
+			case SHOTGUN_SURGERY:
+				str = str + "\"Shotgun Sergery\"";  break;
+			case REFUSED_PARENT_BEQUEST:
+				str = str + "\"Refused Parent Bequest\"";  break;
+			case TRADITION_BREAKER:
+				str = str + "\"Tradition Breaker\"";  break;
+			default:
+				str = str + "";  break;
+			}
+			isFirst = false;
+		}
+		return str;
+	}
+
+}

--- a/src/main/java/zemiA/MethodInfo.java
+++ b/src/main/java/zemiA/MethodInfo.java
@@ -1,0 +1,142 @@
+package zemiA;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+
+
+
+/**
+ * @author gruidae
+ */
+public class MethodInfo implements ElementInfo {
+
+	/* ----- Attribute: 属性 ----- */
+	private String definedClass;  // 定義されているクラス
+	private AccessModifier accessModifier;  // アクセス修飾子
+	private boolean isStatic;  // 静的メソッドか否か
+	private boolean isAbstract;  // 抽象メソッドか否か
+	private String returnType;  // 返し値の型  (null: コンストラクタ)
+	private String name;  // 名前
+	private ArrayList<String> argumentsList= new ArrayList<String>();  // 引数リスト
+
+	private HashSet<Disharmony> disharmnonySet;  // Disharmonyの集合
+
+
+	/* ----- Constructor: コンストラクタ ----- */
+	MethodInfo(String name) {
+		this.setName(name);  return;
+	}
+
+	MethodInfo
+	(String definedClass, String accessModifier, boolean isStatic, boolean isAbstract,
+			boolean returnType, String name)
+	{
+		this.setDefinedClass(definedClass);
+		this.setAccessModifier(accessModifier);
+		this.setIsStatic(isStatic);
+		this.setIsAbstract(isAbstract);
+		this.setName(name);
+
+		/* 引数リストを保存 */
+		return;
+	}
+
+
+	/* ----- setter メソッド ----- */
+	public void setDefinedClass(String definedClass)
+	{
+		this.definedClass = new String(definedClass);  return;
+	}
+
+	@Override
+	public void setAccessModifier(String accessModifier)
+	{
+		switch(accessModifier) {
+		case "private":
+			this.accessModifier = AccessModifier.PRIVATE;  break;
+		case "protected":
+			this.accessModifier = AccessModifier.PROTECTED;  break;
+		case "public":
+			this.accessModifier = AccessModifier.PUBLIC;  break;
+		default:
+			this.accessModifier = AccessModifier.PACKAGE_PRIVATE;
+		}
+
+		return;
+	}
+
+	public void setIsStatic(boolean isStatic)
+	{
+		this.isStatic = isStatic;  return;
+	}
+
+	public void setIsAbstract(boolean isAbstract)
+	{
+		this.isAbstract = isAbstract;  return;
+	}
+
+	public void setReturnType(String returnType)
+	{
+		this.returnType = new String(returnType);
+		return;
+	}
+
+	@Override
+	public void setName(String name)
+	{
+		this.name = new String(name);  return;
+	}
+
+
+	/* ----- Method: メソッド ----- */
+	@Override
+	public String toString() {
+		// TODO 自動生成されたメソッド・スタブ
+		String accessModifier = HelperToString.toString(this.accessModifier);
+		String argumentsList = HelperToString.toString(this.argumentsList);
+		String staticStr = HelperToString.toString(this.isStatic, "static");
+		String abstractStr = HelperToString.toString(this.isAbstract, "abstract");
+		String disharmonies = HelperToString.toString(this.disharmnonySet);
+		String str
+		= String.format("%s.%s(%s) [%s, %s, %s, %s] : %s",
+				this.definedClass, this.name, argumentsList,
+				this.returnType, accessModifier, staticStr, abstractStr, disharmonies);
+		return str;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		// TODO 自動生成されたメソッド・スタブ
+		if (this == obj)  return true;
+		if (obj == null)  return false;
+		if ( !(obj instanceof ClassInfo) )  return false;
+		MethodInfo methodInfo = (MethodInfo) obj;
+
+
+		if ( !(methodInfo.definedClass).equals(this.definedClass) )  return false;
+		if ( !(methodInfo.name).equals(this.name) )  return false;
+		if ( !(methodInfo.returnType).equals(this.returnType) )  return false;
+		if ( !(methodInfo.argumentsList).equals(this.argumentsList) )  return false;  // リストの比較はequalsでいいのか？
+		if ( !(methodInfo.accessModifier).equals(this.accessModifier) )  return false;
+		if ( methodInfo.isStatic != this.isStatic )  return false;
+		if ( methodInfo.isAbstract != this.isAbstract )  return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		// TODO 自動生成されたメソッド・スタブ
+		final int HASH_START = 100, HASH_CONSTANT = 10;
+		int hash = HASH_START;
+		hash = ( hash << 5 ) + this.definedClass.hashCode();
+		hash = ( hash << 5 ) + this.name.hashCode();
+		hash = ( hash << 5 ) + this.returnType.hashCode();
+		hash = ( hash << 5 ) + this.argumentsList.hashCode();
+		hash = ( hash << 5 ) + this.accessModifier.hashCode();
+		hash = this.isStatic?( (hash << 5) + HASH_CONSTANT):(hash << 5);
+		hash = this.isAbstract?( (hash << 5) + HASH_CONSTANT * 2):(hash << 5);
+		return hash;
+	}
+
+}

--- a/src/main/java/zemiA/MetricsCompute.java
+++ b/src/main/java/zemiA/MetricsCompute.java
@@ -1,0 +1,68 @@
+package zemiA;
+
+
+
+
+/**
+ * @author gruidae
+ *
+ * メトリクスを計算するためのヘルパークラス.
+ */
+public class MetricsCompute {
+
+	/** AWM の値を計算する. */
+	public static double averageMethodWeight(int cyclo, int methodNum)
+	{
+		double awm = (double)cyclo / methodNum;
+		return awm;
+	}
+
+
+	/** BOvR の値を計算する. */
+	public static double baseClassOverridingRatio(int overridedMethodNum, int methodNum)
+	{
+		double bovr = (double)overridedMethodNum/methodNum;
+		return bovr;
+	}
+
+
+	/** BUR の値を計算する. */
+	public static double baseClassUsageRatio(int usedSpecializedMethodNum, int specializedMethodNum)
+	{
+		double bur = (double)usedSpecializedMethodNum/specializedMethodNum;
+		return bur;
+	}
+
+
+	/** LAA の値を計算する. */
+	public static double localityOfAttributeAccesses(int atfd, int accessecVariables)
+	{
+		double laa = (double)atfd/accessecVariables;
+		return laa;
+	}
+
+
+	/** PNAS の値を計算する. */
+	public static double percentageOfNewlyAddedServices(int nas, int publicMethodNum)
+	{
+		double pnas = (double)nas/publicMethodNum;
+		return pnas;
+	}
+
+
+	/** WMC の値を計算する. */
+	public static double weightedMethodCount(int cyclo, int loc, int methodNum, int nom, int classNum)
+	{
+		double wmc = ((double)cyclo * loc * nom) / (loc * methodNum * classNum);
+		return wmc;
+	}
+
+
+	/** WOC の値を計算する. */
+	public static double weightOfClass(int functionalMethodNum, int publicMethodNum)
+	{
+		double woc = (double)functionalMethodNum/publicMethodNum;
+		return woc;
+	}
+
+}

--- a/src/main/java/zemiA/ZemiAMain.java
+++ b/src/main/java/zemiA/ZemiAMain.java
@@ -3,6 +3,7 @@ package zemiA;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -10,33 +11,94 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
+
+
+
 public class ZemiAMain {
 
-  public static void main(final String[] args) {
-    List<String> lines = null;
-    try {
-      lines = Files.readAllLines(Paths.get("src/main/java/zemiA/ZemiAMain.java"),
-          StandardCharsets.ISO_8859_1);
-      System.out.println("A");
-    } catch (final Exception e) {
-      System.err.println(e.getMessage());
-      return;
-    }
+	private static final String PACKAGE_PATH = "src/main/java/";
+	private static final String JAVA_PACKAGE = "zemiA/";
+	private static final String JAVA_SOURCE = "ZemiAMain.java";
 
-    final ASTParser parser = ASTParser.newParser(AST.JLS11);
-    parser.setSource(String.join(System.lineSeparator(), lines).toCharArray());
+	private HashSet<ClassInfo> classSet = new HashSet<ClassInfo>();  // クラスの集合
 
-    CompilationUnit unit = null;
-    try {
-      unit = (CompilationUnit) parser.createAST(new NullProgressMonitor());
-    } catch (final Exception e) {
-      System.err.println(e.getMessage());
-      return;
-    }
+	private static ZemiAVisitor visitSource(String javaSourcePath)
+	{
+		List<String> lines = null;
+		try {
+			lines = Files.readAllLines(Paths.get(javaSourcePath),
+					StandardCharsets.ISO_8859_1);
+		} catch (final Exception e) {
+			System.err.println(e.getMessage());
+			return null;
+		}
 
-    final ZemiAVisitor visitor = new ZemiAVisitor();
-    unit.accept(visitor);
 
-    return;  // return 文忘れていますよ！
+		final ASTParser parser = ASTParser.newParser(AST.JLS11);
+		parser.setSource(String.join(System.lineSeparator(), lines).toCharArray());
+
+		CompilationUnit unit = null;
+		try {
+			unit = (CompilationUnit) parser.createAST(new NullProgressMonitor());
+		} catch (final Exception e) {
+			System.err.println(e.getMessage());
+			return null;
+		}
+
+		final ZemiAVisitor visitor = new ZemiAVisitor();
+		unit.accept(visitor);
+
+		return visitor;
+	}
+
+
+	public static void main(final String[] args) {
+		/*  // 元のソース
+		List<String> lines = null;
+		try {
+			lines = Files.readAllLines(Paths.get(PACKAGE_PATH + JAVA_PACKAGE + JAVA_SOURCE),
+					StandardCharsets.ISO_8859_1);
+		} catch (final Exception e) {
+			System.err.println(e.getMessage());
+			return;
+		}
+
+
+		final ASTParser parser = ASTParser.newParser(AST.JLS11);
+		parser.setSource(String.join(System.lineSeparator(), lines).toCharArray());
+
+		CompilationUnit unit = null;
+		try {
+			unit = (CompilationUnit) parser.createAST(new NullProgressMonitor());
+		} catch (final Exception e) {
+			System.err.println(e.getMessage());
+			return;
+		}
+		final ZemiAVisitor visitor = new ZemiAVisitor();
+		unit.accept(visitor);
+		*/
+
+		ZemiAVisitor visitor = visitSource(PACKAGE_PATH + JAVA_PACKAGE + JAVA_SOURCE);
+
+		System.out.println("LOC: " + visitor.getLOC());
+		System.out.println("NOM: " +  visitor.getNOM());
+		System.out.println("CYCLO: " +  visitor.getCYCLO());
+
+/*
+		int a[] = new int[1];
+		for (int i= 0; i < a.length; i++) ;
+		for (int i : a) {
+			;
+		}
+		if (false) {
+			if(true) {; }
+			else {; }
+		} else if (true) ;
+		else ;
+		do {
+			return;
+		} while(true);*/
+
   }
+
 }

--- a/src/main/java/zemiA/ZemiAVisitor.java
+++ b/src/main/java/zemiA/ZemiAVisitor.java
@@ -1,29 +1,211 @@
 package zemiA;
 
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BreakStatement;
+import org.eclipse.jdt.core.dom.CatchClause;
+import org.eclipse.jdt.core.dom.ConditionalExpression;
+import org.eclipse.jdt.core.dom.ContinueStatement;
+import org.eclipse.jdt.core.dom.DoStatement;
+import org.eclipse.jdt.core.dom.EnhancedForStatement;
+import org.eclipse.jdt.core.dom.ForStatement;
+import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.ModuleDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodReference;
+import org.eclipse.jdt.core.dom.SwitchCase;
+import org.eclipse.jdt.core.dom.TryStatement;
+import org.eclipse.jdt.core.dom.WhileStatement;
+
+
+
 
 public class ZemiAVisitor extends ASTVisitor {
 
-  @Override
-  public boolean visit(SimpleName node) {
-    // System.out.println(node.getIdentifier());
-    return super.visit(node);
-  }
+	/* ----- Attribute: 属性 ----- */
+	private int atfd = 0;        // 外部クラスからのアクセス数 (getter, setterメソッド含む)
+	private int cc = 0;          //
+	private int cdisp = 0;       //
+	private int cint = 0;        // 測定中の処理によって呼ばれるメソッド数.
+	private int cm = 0;          // 測定中のメソッドが呼び出すメソッド数 (再帰呼び出しは除く)
+	private int cyclo = 0;       // 線形分岐の数
+	private int fdp = 0;         // アクセスした属性が定義されているクラスの数
+	private int loc = 0;         // 空行, コメント行を含めた行数
+	private int maxNesting = 0;  // {} の最大ネスト数
+	private int nas = 0;         // 子クラスで定義したpublicメソッド数
+	private int noam = 0;        // getter, putterメソッド数
+	private int noav = 0;        // アクセスする変数の総数 (引数 (parameter), local, インスタンス, global変数)
+	private int nom = 0;         // メソッド数
+	private int nopa = 0;        // public属性数
+	private int nprotm = 0;      // protectedメンバ数
+	private int tcc = 0;         // クラス凝集度 (共通にアクセスする属性とメソッドとの関係数)
 
-  @Override
-  public boolean visit(MethodDeclaration node) {
-    // System.out.println(node.toString());
-    return super.visit(node);
-  }
 
-  @Override
-  public boolean visit(ReturnStatement node) {
-	// TODO 自動生成されたメソッド・スタブ
-	return super.visit(node);
-  }
+	/* ----- getter メソッド ----- */
+	public int getATFD() { return this.atfd; }
+	public int getCC() { return this.cc; }
+	public int getCDISP() { return this.cdisp; }
+	public int getCINT() { return this.cint; }
+	public int getCM() { return this.cm; }
+	public int getCYCLO() { return this.cyclo; }
+	public int getFDP() { return this.fdp; }
+	public int getLOC() { return this.loc; }
+	public int getMAXNESTING() { return this.maxNesting; }
+	public int getNAS() { return this.nas; }
+	public int getNOAM() { return this.noam; }
+	public int getNOAV() { return this.noav; }
+	public int getNOM() { return this.nom; }
+	public int getNOPA() { return this.nopa; }
+	public int getNProtM() { return this.nprotm; }
+	public int getTCC() { return this.tcc; }
 
+
+	/* ----- Method: メソッド ----- */
+	@Override
+	public boolean visit(SimpleName node) {
+		// System.out.println(node.getIdentifier());
+		return super.visit(node);
+	}
+
+	/* メンバ定義 */
+	@Override
+	public boolean visit(MethodDeclaration node) {  // メソッド定義検出
+		this.nom++;  // メソッド数のカウント
+		String methodStr = node.toString();
+
+		for(char x: methodStr.toCharArray())  // 命令行のカウント
+			if(x == '\n')  loc++;
+
+		// System.err.println(node.toString());
+		return super.visit(node);
+	}
+
+
+	@Override
+	public boolean visit(Block node) {  // {}ブロック検出
+		// TODO 自動生成されたメソッド・スタブ
+		// System.err.println(node.toString());
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(ConditionalExpression node) {
+		// TODO 自動生成されたメソッド・スタブ
+
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(ModuleDeclaration node) {
+		// TODO 自動生成されたメソッド・スタブ
+		System.out.println(node.toString());
+		return super.visit(node);
+	}
+
+	/* 条件分岐 */
+	@Override
+	public boolean visit(IfStatement node) {  // if文検出 (if の塊. else 単体は検出せず)
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(BreakStatement node) {  // break文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(ContinueStatement node) {  // continue文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(SwitchCase node) {  // case, dafault文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+
+	/* 条件分岐（時によっては無条件分岐） */
+	@Override
+	public boolean visit(ForStatement node) {  // for文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(EnhancedForStatement node) {  // for-each文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(WhileStatement node) {  // while文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(DoStatement node) {  // do-while文検出
+		// TODO 自動生成されたメソッド・スタブ
+		this.cyclo++;
+		return super.visit(node);
+	}
+
+
+	/* 例外処理における条件分岐 */
+	@Override
+	public boolean visit(TryStatement node) {  // try文検出 (try-catch塊につき1回)
+		// TODO 自動生成されたメソッド・スタブ
+		// System.err.println(node.toString());
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(CatchClause node) {  // catch文検出
+		// TODO 自動生成されたメソッド・スタブ
+		// System.err.println(node.toString());
+		return super.visit(node);
+	}
+
+
+	/* 親クラス関係 */
+	@Override
+	public boolean visit(SuperConstructorInvocation node) {  // コンストラクタ定義の検出
+		// TODO 自動生成されたメソッド・スタブ
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(SuperFieldAccess node) {  // 親クラスで定義されたフィールドへのアクセスを検出
+		// TODO 自動生成されたメソッド・スタブ
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(SuperMethodInvocation node) {
+		// TODO 自動生成されたメソッド・スタブ
+		return super.visit(node);
+	}
+
+	@Override
+	public boolean visit(SuperMethodReference node) {  // 親クラスで定義されたメソッドの参照を検出
+		// TODO 自動生成されたメソッド・スタブ
+		// System.err.println(node.toString());
+		return super.visit(node);
+	}
 
 }


### PR DESCRIPTION
全員に連絡.  master にpullしてもいいっていう人はコメント欄にOKなど, この変更を確認したという旨の連絡をお願いします.
ソースコードを読んで分からないことがあったら私に連絡お願いします.

--------------------
次の内容を追加.
・大まかなデータ構造の決定,
  ・ZemiAMain: 主な処理 (構文木の構成 etc. )を中心に行う（予定）
  ・ZemiAVisitor: 構文木のノードをたどる. ここでは測ったメトリクスを一時的に保管したい.
  ・MetricsCompute: 計算系メトリクスを定義したヘルパークラス. メソッドのみを定義.
  ・ElementInfo: ClassInfo, AttributeInfo, MethodInfo の共通部分を抽象化したクラス.
  ・ClassInfo: あるクラスの情報を保存. visitorによる計測ののち, クラス関係のメトリクス（尺度）をここに保存したい.
  ・AttributeInfo: ある属性の情報を保存. visitorによる計測ののち, 属性関係のメトリクス（尺度）をここに保存したい.
  ・MethodInfo: あるメソッドの情報を保存. visitorによる計測ののち, メソッド関係のメトリクス（尺度）をここに保存したい.
  ・HelperToString: ClassInfo, AttributeInfo, MethodInfo の toString の実装を補助するヘルパークラス. 各クラスの toString の形式を最終的な標準出力の1行にしたいと考えている.

・計算を用いて測るメトリクス (AWM etc.) はおそらく実装完了.

・カウントして計測するメトリクスは ZemiAVisit.visit を利用するものと思われる. （試しに cyclo とnom を実装）

・cc, cdisp 以外のメトリクスの意味の下調べを完了. ZemiAVisitor, MetricsCompute 内で簡潔に記している.

・各クラスの toString で定義した形式（formatメソッド参照）を最終的な標準出力の1行にしたいと考えている.